### PR TITLE
Cache npm/bower dependencies on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM node:0.12.9
-ADD . /code
+
 WORKDIR /code
+
+COPY package.json bower.json .bowerrc /code/
+
 RUN npm install && \
   npm install -g bower && \
   npm install -g karma-cli && \
   npm install -g cordova ionic ios-sim && \
   bower install --allow-root
-EXPOSE 8100:8100
+
+COPY . /code
+  
+EXPOSE 8100
 CMD ionic serve --address `/sbin/ip route|awk '/scope/ { print $9 }'`


### PR DESCRIPTION
One good practice on Docker is to run `npm install` before adding all the code. This avoids re running all `npm install` again when just source code is changed.

Also, from dockerfile docs `COPY` should be favored instead of `ADD`.

I take from this example. https://github.com/labianchin/WatchMen/blob/master/Dockerfile

Ping @lipemorais @gomex 

Also, I guess the Readme section "To use docker" is incomplete. I think it is important to mention that you need a Docker host. I would also not make the usage of docker mandatory, as it is just a node project I would not bother dealing with Docker complexities and would rather install node/npm on my machine. But please note, this is an opinion from someone which is not really contribution to the project.
