### PR TITLE
Setting format of the datetime local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ www/ionic.app.min.css
 .idea/
 screenlog.*
 config.xml
-test-results/
+test-results/*

--- a/www/templates/report-address.html
+++ b/www/templates/report-address.html
@@ -16,7 +16,7 @@
         </label>
         <label class="item item-input" ng-class="{'has-errors' : reportForm.date.$invalid && !reportForm.date.$pristine}" ng-min="15-06-2000">
           <span class="input-label">Data e Hora*</span>
-          <input name="date" type="datetime-local" class="date" ng-model="report.date" required>
+          <input name="date" type="datetime-local" placeholder="yyyy-MM-ddTHH:mm:ss" min="2001-01-01T00:00:00" max="2100-12-31T00:00:00" class="date" ng-model="report.date" required>
         </label>
         <div>
           <label class="item item-input item-select" ng-class="{'has-errors' : reportForm.risk.$invalid && !reportForm.risk.$pristine}">

--- a/www/test/functional/page-objects/report.js
+++ b/www/test/functional/page-objects/report.js
@@ -9,9 +9,7 @@
   }
 
   this.fillDate = function (date) {
-    return element(by.className('date')).sendKeys(date.getMonth(),date.getDate(),date.getYear(),
-    protractor.Key.TAB,date.getHours(),date.getMinutes(),
-    protractor.Key.TAB, "PM");
+    return element(by.className('date')).sendKeys('10/10/2016 00:00:00');
   };
 
   this.fillRisk = function (risk) {


### PR DESCRIPTION
Comportamento atual: 
O ano permite até 6 caracteres. 
![image](https://cloud.githubusercontent.com/assets/13666514/20464131/2088272e-af29-11e6-8f96-7a6bec6f5094.png)

Comportamento esperado: 
O campo ano deve permitir apenas 4 caracteres.
![image](https://cloud.githubusercontent.com/assets/13666514/20464136/4a15063e-af29-11e6-9e8f-3f90e77424f5.png)

Deverá ser testado também em aplicações mobile (IOS e Android) para verificar como está se comportando.