### PR TITLE
Moves all devDependencies do dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "ios-sim": "*",
     "node-sass": "^3.4.2",
     "nodemon": "^1.9.1",
-    "protractor": "^4.0.8"
-  },
-  "devDependencies": {
     "eslint": "^1.10.2",
     "eslint-config-airbnb": "^1.0.2",
     "eslint-config-angular": "^0.4.0",


### PR DESCRIPTION
Heroku deployment is failing because it does not install the dev dependencies and some of those dependencies are required to build the application.

Refer to https://devcenter.heroku.com/articles/troubleshooting-node-deploys#ensure-you-aren-t-relying-on-untracked-dependencies